### PR TITLE
[feat] s3연동 - cdn (merge 금지)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,14 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // s3
+    implementation platform("software.amazon.awssdk:bom:2.26.21")
+    implementation "software.amazon.awssdk:s3"
+    implementation "software.amazon.awssdk:sts"
+
+    // .env load용
+    implementation "me.paulschwarz:spring-dotenv:4.0.0"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/codeit/project/deokhugam/domain/book/config/S3Config.java
+++ b/src/main/java/com/codeit/project/deokhugam/domain/book/config/S3Config.java
@@ -1,0 +1,35 @@
+package com.codeit.project.deokhugam.domain.book.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@Profile("prod")
+public class S3Config {
+
+  @Value("${aws.accessKeyId}")
+  private String accessKeyId;
+
+  @Value("${aws.secretKey}")
+  private String secretKey;
+
+  @Value("${aws.region}")
+  private String region;
+
+  @Bean
+  public S3Client s3Client() {
+    AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKeyId, secretKey);
+
+    return S3Client.builder()
+        .region(Region.of(region))
+        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+        .build();
+  }
+
+}

--- a/src/main/java/com/codeit/project/deokhugam/domain/book/config/impl/FileConfigProd.java
+++ b/src/main/java/com/codeit/project/deokhugam/domain/book/config/impl/FileConfigProd.java
@@ -1,0 +1,42 @@
+package com.codeit.project.deokhugam.domain.book.config.impl;
+
+import com.codeit.project.deokhugam.domain.book.config.FileConfig;
+import jakarta.annotation.PostConstruct;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("prod")
+public class FileConfigProd implements FileConfig {
+
+  @Value("${file.upload-dir}")
+  private String uploadDir;
+
+  @PostConstruct
+  public void init() {
+    try {
+      Files.createDirectories(Path.of(uploadDir));
+    } catch (Exception e) {
+      throw new IllegalStateException("업로드 디렉토리 생성 실패 : " + uploadDir, e);
+    }
+  }
+
+  @Override
+  public File getThumbnailUploadDirFile() {
+    try {
+      Path p = Paths.get(uploadDir, "thumbnails");
+      Files.createDirectories(p);
+      return p.toFile();
+    } catch (Exception e) {
+      throw new IllegalStateException("아바타 디렉토리 생성 실패", e);
+    }
+  }
+}
+
+
+

--- a/src/main/java/com/codeit/project/deokhugam/domain/book/storage/impl/FileStorageS3.java
+++ b/src/main/java/com/codeit/project/deokhugam/domain/book/storage/impl/FileStorageS3.java
@@ -1,0 +1,81 @@
+package com.codeit.project.deokhugam.domain.book.storage.impl;
+
+import com.codeit.project.deokhugam.domain.book.storage.FileStorage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@Profile("prod")
+public class FileStorageS3 implements FileStorage {
+  private final S3Client s3Client;
+
+  @Value("${aws.s3.bucket}")
+  private String bucketName;
+
+  @Value("${aws.s3.prefix:uploads}")
+  private String prefix;
+
+  @Value("${aws.region}")
+  private String region;
+
+  @Value("${app.cdn.base-url}")
+  private String cdnBaseUrl;
+
+  //private String ext =".jpg";
+
+  @Override
+  public void saveThumbnailImage(String isbn, MultipartFile thumbnailImage) {
+    String key = String.format("%s/thumbnails/%s",prefix,isbn);
+    deleteFromS3(key);
+    uploadToS3(key,thumbnailImage);
+    log.info("썸네일 업로드 완료 : {}", key);
+  }
+
+  @Override
+  public String getThumbnailImage(String isbn) {
+    String key = String.format("%s/thumbnails/%s",prefix,isbn);
+    return String.format("%s/%s",cdnBaseUrl,key);
+  }
+
+  @Override
+  public void deleteThumbnailImage(String isbn) {
+    String key = String.format("%s/thumbnails/%s",prefix,isbn);
+    deleteFromS3(key);
+    log.info("썸네일 삭제 완료 : {}",key);
+  }
+
+  private void uploadToS3(String key,MultipartFile file) {
+    try {
+      PutObjectRequest putReq = PutObjectRequest.builder()
+          .bucket(bucketName)
+          .key(key)
+          .contentType(file.getContentType())
+          .build();
+
+      s3Client.putObject(putReq, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+    } catch (Exception e) {
+      throw new RuntimeException("S3 업로드 실패: " + key, e);
+    }
+  }
+
+  private void deleteFromS3(String key) {
+    try {
+      s3Client.deleteObject(DeleteObjectRequest.builder()
+          .bucket(bucketName)
+          .key(key)
+          .build());
+    } catch (Exception e) {
+      log.warn("S3 삭제 실패 (무시 가능): {}", key,e);
+    }
+  }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,4 +1,8 @@
 spring:
+  config:
+    activate:
+      on-profile: dev
+
   datasource:
     url: jdbc:postgresql://localhost:5432/deokhugam
     username: deokhugam

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,42 @@
+spring:
+  config:
+    import : optional:dotenv:.
+    activate:
+      on-profile: prod
+
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username : ${DB_USERNAME}
+    password : ${DB_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+
+file:
+  upload-dir: ${FILE_UPLOAD_DIR:/app/uploads}
+
+aws:
+  accessKeyId: ${AWS_ACCESS_KEY}
+  secretKey: ${AWS_SECRET_KEY}
+  region: ${AWS_REGION}
+  s3:
+    bucket: ${AWS_S3_BUCKET}
+    prefix: uploads
+
+app:
+  cdn:
+    base-url: http://d5g2ql7c32oij.cloudfront.net
+
+logging:
+  level:
+    com.codeit.aws: INFO
+    org.hibernate.SQL: off
+    org.hibernate.orm.jdbc.bind: off
+    org.springframework.web: info

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -32,7 +32,7 @@ aws:
 
 app:
   cdn:
-    base-url: http://d5g2ql7c32oij.cloudfront.net
+    base-url: ${CDNURI}
 
 logging:
   level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ spring:
       maxRequestSize: 30MB
 
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:prod}
 
   config:
     import: optional:file:.env[.properties]


### PR DESCRIPTION
s3의 저장된 사진을 불러오기가 가능하도록 만들었다

env에서 cdnuri 의 주석을 바꾸면 정적 웹호스팅 가능(s3에서 설정 필요)
<img width="1123" height="804" alt="image" src="https://github.com/user-attachments/assets/1b995e97-968f-489a-90ab-b98684421f10" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AWS S3를 통한 썸네일 이미지 저장·삭제·조회 및 CDN 경로 제공 기능 추가
  * 프로덕션 전용 파일 업로드 및 썸네일 디렉터리 초기화 동작 추가

* **Chores**
  * 프로덕션 환경 설정 파일 및 프로필 기본값을 prod로 변경
  * AWS SDK와 dotenv 기반 환경변수 로딩 라이브러리 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->